### PR TITLE
Add configuration assets and documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ AI-powered microservices for personalized event recommendations and behavioral n
 - OpenAI APIs
 - API microservices
 
+## 4. Configuration System
+- All configuration files live under `config/` with environment overrides in `config/environments/`.
+- `config/settings.yaml` orchestrates environment, database, vector search, messaging, delivery, and monitoring defaults.
+- Template, delivery, requirements, endpoint, agent, and function registries are documented in dedicated YAML files.
+- `config/config_loader.py` provides an environment-aware loader with caching and hot-reload support.
+- A full HTML reference is available at [`docs/configuration.html`](docs/configuration.html).
+
 ## 5. API Endpoints
 - `POST /api/users/{userId}/recommendations` - Event suggestions
 - `POST /api/events/{eventId}/targeting` - User targeting

--- a/config/agent_personality.yaml
+++ b/config/agent_personality.yaml
@@ -1,0 +1,54 @@
+# LLM Agent configuration describing behavior, tone, and objectives
+agent:
+  name: "DineNudge"
+  version: "1.0"
+  
+  personality:
+    primary_traits:
+      - "enthusiastic"
+      - "helpful"
+      - "socially_aware"
+      - "psychology_driven"
+    tone: "warm_professional"
+    communication_style: "personalized_and_engaging"
+    
+  objectives:
+    primary: "Convert dormant users into active event participants"
+    secondary:
+      - "Increase user engagement through personalized recommendations"
+      - "Build trust through relevant, non-intrusive messaging"
+      - "Foster social connections through strategic nudging"
+    
+  knowledge_domains:
+    - "behavioral_psychology"
+    - "social_dining_preferences"
+    - "event_matching_algorithms"
+    - "notification_optimization"
+    - "user_engagement_strategies"
+    
+  behavioral_guidelines:
+    personalization:
+      use_first_name: true
+      reference_past_events: true
+      acknowledge_preferences: true
+    psychology_application:
+      leverage_social_proof: true
+      create_appropriate_urgency: true
+      reduce_decision_anxiety: true
+    content_constraints:
+      be_concise: true
+      avoid_spam_language: true
+      maintain_authenticity: true
+      respect_user_boundaries: true
+    
+  context_awareness:
+    user_journey_stage:
+      onboarding: "welcoming and educational"
+      active: "engaging and social"
+      dormant: "re-engaging with value focus"
+    time_sensitivity:
+      immediate: "urgent but not pushy"
+      planned: "anticipatory and helpful"
+    social_context:
+      friends_attending: "emphasize social connection"
+      solo_preference: "focus on personal value"

--- a/config/api_endpoints.yaml
+++ b/config/api_endpoints.yaml
@@ -1,0 +1,141 @@
+# API endpoint definitions for Cuculi AI Nudge Notification System
+endpoints:
+  user_recommendations:
+    path: "/api/users/{user_id}/recommendations"
+    method: "POST"
+    description: "Get personalized event recommendations for a user"
+    parameters:
+      path:
+        - name: "user_id"
+          type: "string"
+          required: true
+          description: "MongoDB ObjectId of the user"
+      body:
+        - name: "filters"
+          type: "object"
+          required: false
+          properties:
+            cuisine: "string"
+            neighborhood: "string"
+            price_range: "object"
+            date_range: "object"
+        - name: "limit"
+          type: "integer"
+          required: false
+          default: 10
+          min: 1
+          max: 50
+    response:
+      type: "object"
+      properties:
+        user_id: "string"
+        recommendations: "array"
+        total_count: "integer"
+        generated_at: "datetime"
+
+  event_targeting:
+    path: "/api/events/{event_id}/targeting"
+    method: "POST"
+    description: "Find optimal users for event promotion"
+    parameters:
+      path:
+        - name: "event_id"
+          type: "string"
+          required: true
+      body:
+        - name: "targeting_criteria"
+          type: "object"
+          required: false
+        - name: "min_compatibility"
+          type: "float"
+          required: false
+          default: 0.7
+        - name: "max_users"
+          type: "integer"
+          required: false
+          default: 50
+    response:
+      type: "object"
+      properties:
+        event_id: "string"
+        targeting_results: "object"
+        total_targeted_users: "integer"
+
+  message_generation:
+    path: "/api/messages/generate"
+    method: "POST"
+    description: "Generate personalized message for user-event pair"
+    parameters:
+      body:
+        - name: "user_id"
+          type: "string"
+          required: true
+        - name: "event_id"
+          type: "string"
+          required: true
+        - name: "message_type"
+          type: "string"
+          required: false
+          default: "invitation"
+          enum: ["invitation", "reminder", "follow_up"]
+        - name: "nudge_type"
+          type: "string"
+          required: false
+          default: "new_match"
+    response:
+      type: "object"
+      properties:
+        personalized_message: "string"
+        psychology_principle: "string"
+        confidence_score: "float"
+        delivery_suggestions: "object"
+
+  notification_send:
+    path: "/api/notifications/send"
+    method: "POST"
+    description: "Send notification through specified channel"
+    parameters:
+      body:
+        - name: "user_id"
+          type: "string"
+          required: true
+        - name: "message"
+          type: "string"
+          required: true
+        - name: "channel"
+          type: "string"
+          required: true
+          enum: ["push", "sms", "email"]
+        - name: "priority"
+          type: "string"
+          required: false
+          default: "normal"
+          enum: ["low", "normal", "high", "urgent"]
+    response:
+      type: "object"
+      properties:
+        notification_id: "string"
+        delivery_status: "string"
+        estimated_delivery: "datetime"
+
+  analytics_dashboard:
+    path: "/api/analytics/dashboard"
+    method: "GET"
+    description: "Get system performance metrics"
+    parameters:
+      query:
+        - name: "time_range"
+          type: "string"
+          required: false
+          default: "7d"
+          enum: ["1h", "24h", "7d", "30d"]
+        - name: "metrics"
+          type: "array"
+          required: false
+          items: ["open_rate", "conversion_rate", "delivery_rate"]
+    response:
+      type: "object"
+      properties:
+        metrics: "object"
+        time_range: "string"
+        updated_at: "datetime"

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -1,0 +1,78 @@
+"""Universal configuration loader for the Cuculi AI Nudge Notification System."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+class ConfigurationLoader:
+    """Load YAML configuration files with environment-aware overrides."""
+
+    def __init__(self, config_dir: str = "config") -> None:
+        self.config_dir = Path(config_dir)
+        self._cache: Dict[str, Dict[str, Any]] = {}
+
+    def load_config(self, config_name: str, environment: str | None = None) -> Dict[str, Any]:
+        """Load configuration with optional environment overrides."""
+        cache_key = f"{config_name}_{environment}"
+
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        base_config = self._load_yaml_file(f"{config_name}.yaml")
+
+        if environment:
+            env_file = self.config_dir / "environments" / f"{environment}.yaml"
+            if env_file.exists():
+                env_overrides = self._load_yaml_file(str(env_file.relative_to(self.config_dir)))
+                base_config = self._merge_configs(base_config, env_overrides)
+
+        base_config = self._substitute_env_vars(base_config)
+
+        self._cache[cache_key] = base_config
+        return base_config
+
+    def reload_config(self, config_name: str, environment: str | None = None) -> Dict[str, Any]:
+        """Force reload configuration (useful for updates)."""
+        cache_key = f"{config_name}_{environment}"
+        if cache_key in self._cache:
+            del self._cache[cache_key]
+        return self.load_config(config_name, environment)
+
+    def _load_yaml_file(self, filename: str) -> Dict[str, Any]:
+        """Load YAML file with error handling."""
+        file_path = self.config_dir / filename
+        try:
+            with open(file_path, "r", encoding="utf-8") as file:
+                return yaml.safe_load(file) or {}
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Configuration file not found: {file_path}") from exc
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid YAML in {file_path}: {exc}") from exc
+
+    def _substitute_env_vars(self, config: Any) -> Any:
+        """Recursively substitute environment variables."""
+        if isinstance(config, dict):
+            return {key: self._substitute_env_vars(value) for key, value in config.items()}
+        if isinstance(config, list):
+            return [self._substitute_env_vars(item) for item in config]
+        if isinstance(config, str) and config.startswith("${") and config.endswith("}"):
+            env_var = config[2:-1]
+            return os.getenv(env_var, config)
+        return config
+
+    def _merge_configs(self, base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+        """Deep merge configuration dictionaries."""
+        result = base.copy()
+        for key, value in override.items():
+            if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+                result[key] = self._merge_configs(result[key], value)
+            else:
+                result[key] = value
+        return result
+
+
+config_loader = ConfigurationLoader()

--- a/config/delivery_channels.yaml
+++ b/config/delivery_channels.yaml
@@ -1,0 +1,69 @@
+# Notification Delivery Configuration for the Cuculi Nudge System
+channels:
+  push:
+    provider: "onesignal"
+    enabled: true
+    config:
+      app_id: "${ONESIGNAL_APP_ID}"
+      api_key: "${ONESIGNAL_API_KEY}"
+      timeout: 10
+      retry_attempts: 3
+    formatting:
+      max_title_length: 50
+      max_body_length: 160
+      supports_emoji: true
+      supports_rich_media: true
+    delivery_options:
+      immediate: true
+      scheduled: true
+      timezone_aware: true
+      sound_enabled: true
+      badge_enabled: true
+
+  sms:
+    provider: "twilio"
+    enabled: true
+    config:
+      account_sid: "${TWILIO_ACCOUNT_SID}"
+      auth_token: "${TWILIO_AUTH_TOKEN}"
+      from_number: "${TWILIO_PHONE_NUMBER}"
+      timeout: 15
+      retry_attempts: 2
+    formatting:
+      max_length: 160
+      supports_emoji: false
+      supports_links: true
+    delivery_options:
+      delivery_receipts: true
+      link_tracking: true
+      opt_out_handling: true
+
+  email:
+    provider: "mailchimp"
+    enabled: true
+    config:
+      api_key: "${MAILCHIMP_API_KEY}"
+      list_id: "${MAILCHIMP_LIST_ID}"
+      timeout: 20
+      retry_attempts: 3
+    formatting:
+      max_subject_length: 78
+      supports_html: true
+      supports_attachments: false
+    delivery_options:
+      open_tracking: true
+      click_tracking: true
+      unsubscribe_link: true
+      template_id: "cuculi_event_notification"
+
+# Channel Selection Rules
+selection_rules:
+  user_preference_priority: true
+  fallback_chain: ["push", "sms", "email"]
+  time_sensitive:
+    immediate: ["push", "sms"]
+    scheduled: ["email", "push"]
+  user_engagement_level:
+    high: ["push", "sms"]
+    medium: ["push", "email"]
+    low: ["email", "sms"]

--- a/config/environments/development.yaml
+++ b/config/environments/development.yaml
@@ -1,0 +1,19 @@
+# Development-specific overrides for the Cuculi configuration stack
+environment:
+  name: "development"
+  debug_mode: true
+  log_level: "DEBUG"
+
+database:
+  connection_string: "mongodb://localhost:27017"
+  database_name: "cuculi_ai_notifications_dev"
+  pool_size: 5
+
+openai:
+  model: "gpt-4o-mini"
+  temperature: 0.8
+
+monitoring:
+  performance_tracking: false
+  alert_thresholds:
+    error_rate_maximum: 0.1

--- a/config/environments/production.yaml
+++ b/config/environments/production.yaml
@@ -1,0 +1,30 @@
+# Production overrides provide hardened defaults for live workloads
+environment:
+  name: "production"
+  debug_mode: false
+  log_level: "WARNING"
+
+database:
+  pool_size: 20
+  retry_attempts: 5
+
+openai:
+  temperature: 0.6
+  retry_strategy:
+    max_retries: 5
+    backoff_factor: 3
+
+frequency_limits:
+  cooldown_hours: 36
+  priority_override: false
+
+monitoring:
+  alert_thresholds:
+    open_rate_minimum: 0.2
+    conversion_rate_minimum: 0.08
+    error_rate_maximum: 0.03
+    response_time_maximum: 2500
+  dashboard_refresh_minutes: 3
+
+hitl:
+  sampling_rate: 0.1

--- a/config/environments/staging.yaml
+++ b/config/environments/staging.yaml
@@ -1,0 +1,17 @@
+# Staging overrides emulate production at lower scale
+environment:
+  name: "staging"
+  debug_mode: false
+  log_level: "INFO"
+
+database:
+  connection_string: "mongodb+srv://staging-user:password@staging.mongodb.net/"
+  database_name: "cuculi_ai_notifications_staging"
+  pool_size: 8
+
+frequency_limits:
+  max_daily: 3
+
+monitoring:
+  alert_thresholds:
+    error_rate_maximum: 0.07

--- a/config/event_requirements.yaml
+++ b/config/event_requirements.yaml
@@ -1,0 +1,46 @@
+# Event data requirements for Cuculi AI message generation and targeting
+
+# Minimum event data required for message generation
+required_fields:
+  basic:
+    - "title"
+    - "cuisine"
+    - "start_date"
+    - "venue_id"
+  capacity:
+    - "max_participants"
+    - "total_participants"
+  pricing:
+    - "base_price"
+  context:
+    - "event_vector"         # Required for similarity matching
+
+# Optional but recommended fields
+recommended_fields:
+  details:
+    - "description"
+    - "categories"
+    - "atmosphere_tags"
+  social_proof:
+    - "participant_emails"
+    - "host_rating"
+    - "popularity_score"
+  logistics:
+    - "neighborhood"
+    - "event_type"
+
+# Data quality requirements
+quality_requirements:
+  future_event: true          # Must be in the future
+  available_spots: true       # Must have capacity
+  venue_info_complete: true   # Venue must have name, location
+  pricing_valid: true         # Price must be > 0
+  vector_exists: true         # Must have event vector
+
+# Event eligibility criteria
+eligibility:
+  minimum_days_before: 1      # At least 1 day notice
+  maximum_days_before: 30     # Not more than 30 days out
+  minimum_spots_available: 1
+  status: "active"
+  venue_rating_minimum: 3.0

--- a/config/nudge_templates.yaml
+++ b/config/nudge_templates.yaml
@@ -1,0 +1,77 @@
+# Psychology-Driven Message Templates for Cuculi AI Nudges
+templates:
+  friend_interest:
+    psychology_principle: "social_proof"
+    base_template: "{friend_count} of your friends are interested in {event_title}! Join them for {cuisine} at {venue_name}."
+    variations:
+      single_friend: "{friend_name} is going to {event_title}. Join them!"
+      multiple_friends: "{friend_count} friends are attending {event_title}. Don't miss out!"
+    variables:
+      friend_count:
+        type: "integer"
+        constraints:
+          min: 1
+          max: 10
+      friend_name:
+        type: "string"
+        constraints:
+          max_length: 20
+      event_title:
+        type: "string"
+        required: true
+      cuisine:
+        type: "string"
+        required: false
+    constraints:
+      max_length: 160
+      min_confidence: 0.7
+      requires_social_proof: true
+
+  scarcity_alert:
+    psychology_principle: "urgency_scarcity"
+    base_template: "Only {spots_remaining} spots left for {event_title}! Reserve now before it's full."
+    variables:
+      spots_remaining:
+        type: "integer"
+        constraints:
+          min: 1
+          max: 10
+      event_title:
+        type: "string"
+        required: true
+    constraints:
+      max_length: 160
+      urgency_required: true
+      scarcity_threshold: 10  # Only trigger when ≤10 spots
+
+  similar_taste:
+    psychology_principle: "personalization"
+    base_template: "Perfect for you! {event_title} features {cuisine} - just like the {past_event} you loved."
+    variables:
+      compatibility_score:
+        type: "float"
+        constraints:
+          min: 0.7
+          max: 1.0
+      past_event:
+        type: "string"
+        required: false
+    constraints:
+      personalization_required: true
+      min_compatibility: 0.75
+
+  host_reputation:
+    psychology_principle: "authority"
+    base_template: "Join an event by {host_name} (⭐{rating}/5) - known for amazing {cuisine} experiences!"
+    variables:
+      host_name:
+        type: "string"
+        required: true
+      rating:
+        type: "float"
+        constraints:
+          min: 4.0
+          max: 5.0
+    constraints:
+      min_host_rating: 4.0
+      authority_signal_required: true

--- a/config/python_functions.yaml
+++ b/config/python_functions.yaml
@@ -1,0 +1,72 @@
+# Mapping of critical Python modules, functions, and their associated tests
+modules:
+  config:
+    directory: "src/core/config"
+    functions:
+      - name: "load_yaml_configuration"
+        file: "config_manager.py"
+        description: "Load and validate YAML configuration files"
+        test_file: "tests/unit/test_config/test_config_manager.py"
+        critical: true
+      - name: "validate_configuration_schema"
+        file: "config_manager.py"
+        description: "Validate config against schema"
+        test_file: "tests/unit/test_config/test_config_manager.py"
+        critical: true
+
+  database:
+    directory: "src/core/database"
+    functions:
+      - name: "create_mongodb_connection"
+        file: "mongodb_client.py"
+        description: "Establish MongoDB connection"
+        test_file: "tests/unit/test_database/test_mongodb_client.py"
+        critical: true
+      - name: "execute_vector_similarity_search"
+        file: "vector_operations.py"
+        description: "Perform vector similarity search"
+        test_file: "tests/unit/test_database/test_vector_operations.py"
+        critical: true
+      - name: "assemble_message_context"
+        file: "data_retrieval.py"
+        description: "Gather user and event context for messaging"
+        test_file: "tests/unit/test_database/test_data_retrieval.py"
+        critical: true
+
+  ai:
+    directory: "src/core/ai"
+    functions:
+      - name: "generate_psychology_driven_prompt"
+        file: "prompt_engine.py"
+        description: "Create AI prompts with psychology principles"
+        test_file: "tests/unit/test_ai/test_prompt_engine.py"
+        critical: true
+      - name: "create_personalized_message"
+        file: "content_generator.py"
+        description: "Generate personalized notification content"
+        test_file: "tests/unit/test_ai/test_content_generator.py"
+        critical: true
+
+# Testing Configuration
+testing:
+  coverage_requirements:
+    minimum_percentage: 85
+    critical_functions: 95
+  performance_benchmarks:
+    max_response_time_ms: 3000
+    max_memory_usage_mb: 200
+  test_categories:
+    unit: "tests/unit/"
+    integration: "tests/integration/"
+    e2e: "tests/e2e/"
+  mock_configurations:
+    openai_api: true
+    mongodb: false  # Use test database
+    delivery_channels: true
+
+# Documentation
+documentation:
+  auto_generate: true
+  formats: ["markdown", "html"]
+  include_examples: true
+  update_on_deploy: true

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,0 +1,134 @@
+# Cuculi AI Nudge Notification System - Main System Configuration
+# This file defines global configuration parameters and defaults.
+
+# Environment Configuration
+environment:
+  name: "development"  # development, staging, production
+  debug_mode: true
+  log_level: "INFO"    # DEBUG, INFO, WARNING, ERROR, CRITICAL
+  timezone: "America/New_York"
+
+# Database Configuration
+database:
+  connection_string: "mongodb+srv://cuculi-production-ai:AlGycfYGlJG5p5UQ@cuculi-prod-ai.yggar.mongodb.net/"
+  database_name: "cuculi_ai_notifications"
+  timeout_seconds: 30
+  pool_size: 10
+  retry_attempts: 3
+  collections:
+    users: "users"
+    events: "events"
+    notifications: "notifications"
+    venues: "venues"
+    connections: "friends_connections"
+
+# Vector Search Configuration
+vector_search:
+  enabled: true
+  index_names:
+    user_vector: "user_vector_index"
+    event_vector: "event_vector_index"
+  search_params:
+    dimensions: 3072
+    similarity_metric: "cosine"  # cosine, euclidean, dotProduct
+    num_candidates: 100
+    similarity_threshold: 0.7    # Minimum compatibility score to send message
+    max_results: 20
+  confidence_requirements:
+    minimum_confidence: 0.75     # Minimum confidence to send message
+    high_confidence: 0.85        # Threshold for high-priority messages
+    auto_approve_threshold: 0.9   # Auto-approve without HITL review
+
+# OpenAI Configuration
+openai:
+  api_key: "${OPENAI_API_KEY}"
+  model: "gpt-4o"
+  temperature: 0.7
+  max_tokens: 200
+  timeout_seconds: 30
+  rate_limits:
+    requests_per_minute: 60
+    tokens_per_minute: 40000
+  retry_strategy:
+    max_retries: 3
+    backoff_factor: 2
+    max_backoff: 60
+
+# Psychology & Nudge Configuration
+psychology:
+  nudge_types:
+    - "friend_interest"
+    - "scarcity_alert"
+    - "similar_taste"
+    - "host_reputation"
+    - "new_match"
+    - "location_convenience"
+    - "price_range_match"
+    - "professional_overlap"
+  effectiveness_weights:
+    friend_interest: 0.185
+    scarcity_alert: 0.128
+    similar_taste: 0.093
+    host_reputation: 0.098
+    new_match: 0.089
+  segmentation:
+    high_engagement: 3  # events attended
+    dormant_threshold: 14  # days since last activity
+    new_user_threshold: 7   # days since signup
+
+# Notification Frequency Limits
+frequency_limits:
+  max_daily: 2
+  max_weekly: 5
+  max_monthly: 15
+  cooldown_hours: 24
+  priority_override: true  # Allow high-priority messages to bypass limits
+  user_preferences_override: true
+
+# Message Generation Configuration
+message_generation:
+  constraints:
+    max_length: 160      # characters
+    min_length: 50       # characters
+    max_emoji: 2
+    tone: "enthusiastic" # enthusiastic, professional, casual
+  quality_requirements:
+    grammar_check: true
+    relevance_threshold: 0.8
+    appropriateness_check: true
+    personalization_required: true
+  fallback_strategy: "generic_template"
+
+# Delivery Channel Priority
+delivery:
+  default_priority: ["push", "sms", "email"]
+  channel_selection_criteria:
+    new_users: ["email", "push", "sms"]
+    high_engagement: ["push", "sms", "email"]
+    dormant_users: ["email", "sms", "push"]
+  timing:
+    optimal_hours: [18, 19, 20]  # 6-8 PM
+    timezone_aware: true
+    respect_dnd: true  # do not disturb hours
+
+# Monitoring & Analytics
+monitoring:
+  performance_tracking: true
+  metrics_retention_days: 90
+  alert_thresholds:
+    open_rate_minimum: 0.15
+    conversion_rate_minimum: 0.05
+    error_rate_maximum: 0.05
+    response_time_maximum: 3000  # milliseconds
+  dashboard_refresh_minutes: 5
+
+# Human-in-the-Loop (HITL) Configuration
+hitl:
+  enabled: true
+  review_triggers:
+    low_confidence: 0.8
+    new_nudge_type: true
+    vip_user: true
+    high_value_event: true
+  sampling_rate: 0.05  # 5% random sampling
+  auto_approve_threshold: 0.9

--- a/config/user_requirements.yaml
+++ b/config/user_requirements.yaml
@@ -1,0 +1,45 @@
+# Data requirements for user profiles referenced during nudge generation
+# Fields with comments explain validation expectations for downstream services.
+
+# Minimum user data required for message generation
+required_fields:
+  profile:
+    - "first_name"
+    - "email"
+    - "homeNeighborhood"
+  preferences:
+    - "preferred_cuisines"    # At least 1 cuisine
+    - "avg_spend"            # Budget range
+  behavioral_data:
+    - "last_active_at"       # Must be within 60 days
+    - "user_vector"          # Required for similarity matching
+
+# Optional but recommended fields
+recommended_fields:
+  profile:
+    - "age"
+    - "occupation"
+    - "workNeighborhood"
+  preferences:
+    - "preferred_time"
+    - "preferred_group_size"
+    - "dietary_preferences"
+  behavioral_data:
+    - "events_attended"
+    - "events_viewed"
+    - "social_interactions"
+
+# Data quality requirements
+quality_requirements:
+  profile_completion_minimum: 0.6  # 60% of required fields
+  vector_exists: true
+  active_within_days: 60
+  email_verified: true
+  notification_consent: true
+
+# Exclusion criteria
+exclusions:
+  inactive_days: 90
+  unsubscribed: true
+  blocked_status: true
+  incomplete_profile_threshold: 0.4  # Less than 40% complete

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cuculi AI Configuration Reference</title>
+  <style>
+    :root {
+      --primary: #5b6cff;
+      --accent: #38bdf8;
+      --dark: #0f172a;
+      --text: #1e293b;
+      --light: #f8fafc;
+    }
+
+    body {
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: var(--text);
+      background: var(--light);
+      margin: 0;
+      line-height: 1.7;
+    }
+
+    header {
+      background: linear-gradient(135deg, rgba(91, 108, 255, 0.9), rgba(56, 189, 248, 0.85));
+      color: white;
+      padding: 64px 24px;
+      text-align: center;
+    }
+
+    header h1 {
+      margin-bottom: 12px;
+      font-size: 2.8rem;
+    }
+
+    header p {
+      margin: 0 auto;
+      max-width: 760px;
+      color: rgba(255, 255, 255, 0.9);
+    }
+
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 48px 24px 80px;
+    }
+
+    section {
+      background: white;
+      padding: 32px;
+      border-radius: 16px;
+      box-shadow: 0 20px 45px -35px rgba(15, 23, 42, 0.45);
+      margin-bottom: 32px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    h2 {
+      color: var(--dark);
+      margin-bottom: 16px;
+      font-size: 1.9rem;
+    }
+
+    h3 {
+      color: var(--primary);
+      margin-top: 24px;
+      margin-bottom: 12px;
+    }
+
+    code, pre {
+      background: rgba(148, 163, 184, 0.15);
+      padding: 12px;
+      border-radius: 12px;
+      display: block;
+      overflow-x: auto;
+    }
+
+    ul {
+      padding-left: 20px;
+    }
+
+    .file-grid {
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      margin-top: 24px;
+    }
+
+    .file-card {
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      border-radius: 12px;
+      padding: 16px;
+      background: white;
+    }
+
+    footer {
+      text-align: center;
+      padding: 32px;
+      font-size: 0.9rem;
+      color: rgba(15, 23, 42, 0.65);
+    }
+
+    a {
+      color: var(--primary);
+    }
+
+    .pill {
+      display: inline-block;
+      background: rgba(56, 189, 248, 0.15);
+      color: var(--accent);
+      padding: 6px 12px;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 16px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="pill">Configuration Reference</div>
+    <h1>Cuculi AI Nudge Notification System</h1>
+    <p>
+      This guide documents the configuration surface for the Cuculi AI platform.
+      It explains directory structure, YAML specifications, and the Python loader
+      used to hydrate the application with environment-aware settings.
+    </p>
+  </header>
+
+  <main>
+    <section>
+      <h2>Directory Overview</h2>
+      <p>
+        Configuration assets live under the <code>config/</code> directory and are organised by concern.
+        Environment overrides are stored in <code>config/environments/</code> and layered on top of the base files.
+      </p>
+      <pre><code>config/
+├── settings.yaml
+├── nudge_templates.yaml
+├── delivery_channels.yaml
+├── user_requirements.yaml
+├── event_requirements.yaml
+├── api_endpoints.yaml
+├── agent_personality.yaml
+├── python_functions.yaml
+├── config_loader.py
+└── environments/
+    ├── development.yaml
+    ├── staging.yaml
+    └── production.yaml</code></pre>
+    </section>
+
+    <section>
+      <h2>Configuration Modules</h2>
+      <div class="file-grid">
+        <div class="file-card">
+          <h3>settings.yaml</h3>
+          <p>Main system configuration covering environment modes, database access, vector search, OpenAI, and monitoring.</p>
+        </div>
+        <div class="file-card">
+          <h3>nudge_templates.yaml</h3>
+          <p>Defines psychology-backed message templates, variation logic, and variable constraints for LLM prompts.</p>
+        </div>
+        <div class="file-card">
+          <h3>delivery_channels.yaml</h3>
+          <p>Specifies push, SMS, and email providers with formatting limits and channel selection rules.</p>
+        </div>
+        <div class="file-card">
+          <h3>user_requirements.yaml</h3>
+          <p>Outlines mandatory, recommended, and exclusion criteria for user profiles used during targeting.</p>
+        </div>
+        <div class="file-card">
+          <h3>event_requirements.yaml</h3>
+          <p>Captures event data expectations, data quality checks, and eligibility constraints.</p>
+        </div>
+        <div class="file-card">
+          <h3>api_endpoints.yaml</h3>
+          <p>Documents REST endpoints including request parameters and response schemas for AI-powered services.</p>
+        </div>
+        <div class="file-card">
+          <h3>agent_personality.yaml</h3>
+          <p>Encodes behavioural traits, objectives, and communication guidelines for the DineNudge agent.</p>
+        </div>
+        <div class="file-card">
+          <h3>python_functions.yaml</h3>
+          <p>Maps critical Python functions to their files, tests, and coverage expectations.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Environment Overrides</h2>
+      <p>
+        Environment-specific YAML files provide targeted overrides for development, staging, and production.
+        The loader merges these overrides with base configuration to produce final runtime settings.
+      </p>
+      <ul>
+        <li><strong>development.yaml:</strong> Local MongoDB connection, verbose logging, and disabled monitoring.</li>
+        <li><strong>staging.yaml:</strong> Mirrors production but relaxes notification caps for testing.</li>
+        <li><strong>production.yaml:</strong> Hardened limits, stricter monitoring thresholds, and lower temperature for stability.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Configuration Loader</h2>
+      <p>
+        The <code>config_loader.py</code> module centralises loading logic. It caches values for performance, applies
+        deep merges for overrides, and replaces environment variable tokens (e.g. <code>${OPENAI_API_KEY}</code>)
+        with values from the host process.
+      </p>
+      <pre><code>from config.config_loader import config_loader
+
+settings = config_loader.load_config("settings", environment="production")
+templates = config_loader.load_config("nudge_templates")</code></pre>
+      <p>
+        Use <code>reload_config</code> to invalidate cache entries when files change. This enables hot reloading for long-lived processes.
+      </p>
+    </section>
+
+    <section>
+      <h2>Testing & Documentation</h2>
+      <p>
+        Critical modules, test locations, and coverage requirements are tracked in <code>python_functions.yaml</code>.
+        Automation pipelines can parse this file to enforce quality gates and generate additional documentation.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    &copy; <script>document.write(new Date().getFullYear());</script> Cuculi AI. Configuration docs for the nudge notification platform.
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -197,6 +197,9 @@
       <span class="pill" style="display:inline-block;background:rgba(56,189,248,0.15);color:#bae6fd;padding:8px 16px;border-radius:999px;font-weight:600;text-transform:uppercase;font-size:0.75rem;letter-spacing:2px;">AI-Powered Engagement</span>
       <h1>Cuculi AI Recommendation Engine</h1>
       <p class="lead">Personalized event recommendations and psychology-driven nudges designed to re-engage dormant users with precise targeting and compelling content.</p>
+      <div style="margin-top:32px;display:flex;justify-content:center;gap:16px;flex-wrap:wrap;">
+        <a href="docs/configuration.html" style="background:#38bdf8;color:#0f172a;padding:12px 24px;border-radius:999px;font-weight:600;text-decoration:none;box-shadow:0 20px 40px -30px rgba(56,189,248,0.9);">View Configuration Reference</a>
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- add the configuration YAML suite, environment overrides, and loader module
- publish an HTML configuration reference and link it from the landing page
- expand the README to describe the configuration system and documentation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d96dfc8c608325be1f4fba41856d74